### PR TITLE
Remove redundant error checking in process_course

### DIFF
--- a/server.py
+++ b/server.py
@@ -262,10 +262,6 @@ def process_course(raw_course):
         if not match:
             raise ScrapeError("malformed schedule slot: {}".format(repr(slot)))
         days, start, end, location = match.groups()
-        for day in days:
-            if day not in DAYS_OF_WEEK:
-                raise ScrapeError("unknown day of week {} in schedule slot {}"
-                                  .format(repr(day), repr(slot)))
         days = "".join(
             sorted(set(days), key=lambda day: DAYS_OF_WEEK.index(day)))
         if not (start.endswith("AM") or start.endswith("PM")):

--- a/server.py
+++ b/server.py
@@ -224,7 +224,7 @@ def course_sort_key(course):
 
 COURSE_REGEX = r"([A-Z]+) *?([0-9]+) *([A-Z]*[0-9]?) *([A-Z]{2})-([0-9]+)"
 SCHEDULE_REGEX = (r"([MTWRFSU]+)\xa0([0-9]+:[0-9]+(?: ?[AP]M)?) - "
-                  "([0-9]+:[0-9]+ ?[AP]M); ([A-Za-z0-9, ]+)")
+                  r"([0-9]+:[0-9]+ ?[AP]M); ([A-Za-z0-9, ]+)")
 DAYS_OF_WEEK = "MTWRFSU"
 
 def process_course(raw_course):
@@ -234,33 +234,8 @@ def process_course(raw_course):
         raise ScrapeError(
             "malformed course code: {}".format(repr(course_code)))
     department, course_number, num_suffix, school, section = match.groups()
-    if not department:
-        raise ScrapeError("empty string for department")
-    if "/" in department:
-        raise ScrapeError("department contains slashes: {}"
-                          .format(repr(department)))
-    try:
-        course_number = int(course_number)
-    except ValueError:
-        raise ScrapeError(
-            "malformed course number: {}".format(repr(course_number)))
-    if course_number <= 0:
-        raise ScrapeError(
-            "non-positive course number: {}".format(course_number))
-    if "/" in num_suffix:
-        raise ScrapeError("course code suffix contains slashes: {}"
-                          .format(repr(num_suffix)))
-    if not school:
-        raise ScrapeError("empty string for school")
-    if "/" in school:
-        raise ScrapeError("school contains slashes: {}".format(repr(school)))
-    try:
-        section = int(section)
-    except ValueError:
-        raise ScrapeError(
-            "malformed section number: {}".format(repr(section)))
-    if section <= 0:
-        raise ScrapeError("non-positive section number: {}".format(section))
+    course_number = int(course_number)
+    section = int(section)
     course_name = raw_course["course_name"].strip()
     if not course_name:
         raise ScrapeError("empty string for course name")
@@ -275,10 +250,6 @@ def process_course(raw_course):
         raise ScrapeError(
             "malformed seat count: {}".format(repr(raw_course["seats"])))
     open_seats, total_seats = map(int, match.groups())
-    if open_seats < 0:
-        raise ScrapeError("negative open seat count: {}".format(open_seats))
-    if total_seats < 0:
-        raise ScrapeError("negative total seat count: {}".format(total_seats))
     course_status = raw_course["status"].lower()
     if course_status not in ("open", "closed", "reopened"):
         raise ScrapeError(
@@ -297,8 +268,6 @@ def process_course(raw_course):
                                   .format(repr(day), repr(slot)))
         days = "".join(
             sorted(set(days), key=lambda day: DAYS_OF_WEEK.index(day)))
-        if not days:
-            raise ScrapeError("no days in schedule slot {}".format(repr(slot)))
         if not (start.endswith("AM") or start.endswith("PM")):
             start += end[-2:]
         try:


### PR DESCRIPTION
Many error checkings are redundant. The errors that the removed lines are
intending to catch should have already be caught by regex parsing.
For example, COURSE_REGEX requires the department regex group to
contain one or more capital english alphabets [A-Z]+. Therefore,
if department is empty or contain slash, ScrapeError will be raised
from line 234 since the regex does not match. Similarily, if
open_seats or total_seats is less than 0, the regex wouldn't be
matched and the error on line 278 will be raised.